### PR TITLE
feat: 로그아웃 API 프론트엔드 명세에 맞춰 코드 수정

### DIFF
--- a/src/main/java/team/lindo/backend/application/user/service/UserService.java
+++ b/src/main/java/team/lindo/backend/application/user/service/UserService.java
@@ -1,6 +1,7 @@
 package team.lindo.backend.application.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -12,6 +13,7 @@ import team.lindo.backend.application.board.repository.posting.PostingRepository
 import team.lindo.backend.application.common.exception.UserAlreadyExistsException;
 import team.lindo.backend.application.social.repository.follow.FollowRepository;
 import team.lindo.backend.application.user.dto.LoginRequestDto;
+import team.lindo.backend.application.user.dto.LogoutResponseDto;
 import team.lindo.backend.application.user.dto.SignUpRequestDto;
 import team.lindo.backend.application.user.dto.UserSummaryDto;
 import team.lindo.backend.application.user.entity.Role;
@@ -87,8 +89,9 @@ public class UserService {
         return new UserSummaryDto(user);
     }
 
-    public void logout() {  //! JWT 기반 인증으로 수정 시 토큰을 삭제하는 방식으로 바꿔야 함
+    public LogoutResponseDto logout() {  //! JWT 기반 인증으로 수정 시 토큰을 삭제하는 방식으로 바꿔야 함
         SecurityContextHolder.clearContext();
+        return new LogoutResponseDto("로그아웃 되었습니다.");
     }
 
     public UserSummaryDto loadUserInfo(Long id) {

--- a/src/main/java/team/lindo/backend/presentation/controller/app/UserController.java
+++ b/src/main/java/team/lindo/backend/presentation/controller/app/UserController.java
@@ -31,8 +31,7 @@ public class UserController {
 
     @PostMapping("/logout")  // GET으로 하면 그냥 url 입력했는데 로그아웃될 수 있으니 위험 + 로그아웃 -> 서버의 상태 변경하는 행동
     public ResponseEntity<LogoutResponseDto> logout() {
-        userService.logout();
-        return ResponseEntity.ok(new LogoutResponseDto("Logged out successfully"));
+        return ResponseEntity.ok(userService.logout());
     }
 
     @GetMapping("/load")


### PR DESCRIPTION
- 프론트엔드 API 명세에 맞춰 로그아웃 응답 형식 변경 (DTO로 응답)
- UserService 및 UserController의 로그아웃 관련 메서드 수정
- 기존 문자열 응답을 DTO 응답으로 변경
- 로컬 환경에서 API 테스트를 통해 정상 동작 확인